### PR TITLE
Fix counters not updated when user is deleted

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -147,6 +147,18 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    @user.likes.each do |post|
+      post.likes_count -= 1
+      post.save
+    end
+    @user.followees.each do |user|
+      user.followers_count -= 1
+      user.save
+    end
+    @user.followers.each do |user|
+      user.followees_count -= 1
+      user.save
+    end
     @user.destroy
     UserMailer.with(user: @user, is_deleted: true).notify_email.deliver_now
     redirect_to '/admin/user'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: 'fotobook-1.onrender.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:         'smtp-relay.brevo.com',


### PR DESCRIPTION
When a user is deleted, decrement the likes_count of liked posts, followees_count and followers_count of corresponding users.